### PR TITLE
fix(next.config): :bug: fix variable typo

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,6 @@ module.exports = {
     UMAMI_WEB_ID: process.env.UMAMI_WEB_ID,
     UMAMI_SRC: process.env.UMAMI_SRC,
     SANITY_DATASET: process.env.SANITY_DATASET,
-    SANITY_PROJECID: process.env.SANITY_PROJECID,
+    SANITY_PROJECTID: process.env.SANITY_PROJECTID,
   },
 };

--- a/src/lib/services/sanity-config.ts
+++ b/src/lib/services/sanity-config.ts
@@ -17,7 +17,6 @@ export const sanityConfig = {
 export const previewClient = createClient({
   ...sanityConfig,
   useCdn: false,
-  token: process.env.SANITY_API_TOKEN,
 });
 
 export const sanityClient = createClient(sanityConfig);


### PR DESCRIPTION
# Description
Fix env var typo in `next.config.js` that caused the web crashes

# Linked Issues

# Preview or Screenshot
