### PR TITLE
refactor(BottomNav, ProjectCard, home page): :recycle: Implement outline for hover link style

### DIFF
--- a/src/components/layouts/BottomNav.tsx
+++ b/src/components/layouts/BottomNav.tsx
@@ -26,7 +26,7 @@ const BottomNav = () => {
           href={menu.route}
           className={clsxm(
             "flex flex-col items-center justify-center",
-            "hover:rounded-md hover:border hover:border-primary-200",
+            "hover:rounded-md hover:outline hover:outline-primary-200 dark:hover:outline-lightsteel-200",
             "focus:border-none"
           )}
         >

--- a/src/components/ui/ProjectCard.tsx
+++ b/src/components/ui/ProjectCard.tsx
@@ -40,8 +40,7 @@ const ProjectCard = ({
         className={clsxm(
           "my-4 rounded-lg border-2 border-lightsteel-300 py-4 px-6 dark:border-lightsteel-500",
           "duration-300 ease-in group-hover:-translate-y-1",
-          "group-hover:border-lightsteel-300",
-          "group-hover:ring group-hover:ring-lightsteel-300",
+          "group-hover:outline group-hover:outline-lightsteel-300",
           "bg-gainsboro-100 dark:bg-charcoal-500",
           "h-full",
           "flex flex-col justify-between"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -145,8 +145,8 @@ export default function Home({
                 href={project.project_url}
                 className={clsxm(
                   "relative w-full overflow-hidden rounded-md",
-                  "hover:border-zinc-400 hover:ring hover:ring-zinc-400",
-                  "dark:hover:border-zinc-100 dark:hover:ring-zinc-100",
+                  "hover:outline hover:outline-zinc-400",
+                  "dark:hover:outline-zinc-100",
                   "duration-200 ease-in hover:-translate-y-1"
                 )}
                 onClickCapture={() =>


### PR DESCRIPTION
# Description
Implement `outline` for hover link card styling. It's the best practice because outline didn't affect the DOM UI.

# Linked Issues
Close [https://github.com/yehezkielgunawan/yehezgun-v3/issues/220](https://github.com/yehezkielgunawan/yehezgun-v3/issues/220)

# Preview or Screenshot
